### PR TITLE
Changes build settings and fixed timer function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,21 @@ RASPI3_BOOT := boot.s
 all: gcc raspi3
 
 gcc:
-	@echo Compiling for GCC...
+	@echo Compiling for GCC 11...
 
 	@g++ $(SOURCE_FILES) \
 	-I $(DIR_INCLUDE) \
 	-o $(DIR_OUTPUT)/gcc/game.exe \
+	-std=c++11 \
+	-D INJECT_GCC
+
+gcc-legacy:
+	@echo Compiling for GCC 0X...
+
+	@g++ $(SOURCE_FILES) \
+	-I $(DIR_INCLUDE) \
+	-o $(DIR_OUTPUT)/gcc/game.exe \
+	-std=c++0X \
 	-D INJECT_GCC
 
 raspi3:

--- a/source/timer/TimerGcc.cpp
+++ b/source/timer/TimerGcc.cpp
@@ -1,13 +1,17 @@
 #include "timer/TimerGcc.h"
-//#include <chrono>
-//#include <thread>
+#include <chrono>
+#include <thread>
+
+std::chrono::time_point<std::chrono::system_clock> startTime;
 
 void TimerGcc::start() {
-    /* No Op */
+    startTime = std::chrono::system_clock::now();
 }
 
 void TimerGcc::waitMicro(uint32_t us) {
-    //Treads are pretty great
-    //Sleep the currtly active treads for the given time
-    //std::this_thread::sleep_for(std::chrono::microseconds(us));
+    auto now = std::chrono::system_clock::now().time_since_epoch();
+    auto endTime = startTime.time_since_epoch() + std::chrono::microseconds(us);
+    if (now < endTime){
+        std::this_thread::sleep_for(endTime - now);
+    }
 }


### PR DESCRIPTION
Creating a pull request for this to ensure it is reviewed and accepted.

Added `-std=c++11` to build settings by default and created `gcc-legacy` options which will build using the `-std=c++0X` option.

Also fixed the timer module so it uses chrono and checks time duration before sleeping.